### PR TITLE
Add super admin role and super admin registration

### DIFF
--- a/bruno-api-collection/Get all users.bru
+++ b/bruno-api-collection/Get all users.bru
@@ -11,5 +11,5 @@ get {
 }
 
 auth:bearer {
-  token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImpvZUBlbWFpbC5jb20iLCJleHAiOjE3Mzg4OTU0MzR9.ic1Ex-qS0MHGFcQgz-3Ud73zChxDvajZKTtKqUKIlhw
+  token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InN1cGVyYWRtaW5AZW1haWwuY29tIiwiZXhwIjoxNzM5MjQyMjYyfQ.qmKEqjhTNWPlLbbB0wuo9aAjwWofm6wg1to4rwS1RZA
 }

--- a/bruno-api-collection/Login.bru
+++ b/bruno-api-collection/Login.bru
@@ -1,7 +1,7 @@
 meta {
   name: Login
   type: http
-  seq: 3
+  seq: 2
 }
 
 post {

--- a/bruno-api-collection/Register super admin.bru
+++ b/bruno-api-collection/Register super admin.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Register super admin
+  type: http
+  seq: 3
+}
+
+post {
+  url: http://localhost:8787/api/v1/auth/register/super-admin
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "email": "super.admin@email.com",
+    "password": "super-admin"
+  }
+}
+
+script:post-response {
+  res.getHeader("authorization")
+}

--- a/bruno-api-collection/Register user.bru
+++ b/bruno-api-collection/Register user.bru
@@ -1,7 +1,7 @@
 meta {
   name: Register user
   type: http
-  seq: 2
+  seq: 1
 }
 
 post {

--- a/bruno-api-collection/Update user.bru
+++ b/bruno-api-collection/Update user.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Update user
+  type: http
+  seq: 8
+}
+
+get {
+  url: http://localhost:8787/api/v1/users/current
+  body: none
+  auth: bearer
+}
+
+headers {
+  Authorization: {{auth_header}}
+}
+
+auth:bearer {
+  token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImpvZUBlbWFpbC5jb20iLCJleHAiOjE3Mzg4OTU0MzR9.ic1Ex-qS0MHGFcQgz-3Ud73zChxDvajZKTtKqUKIlhw
+}

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -4,8 +4,9 @@ import { eq } from "drizzle-orm";
 import { users } from "../db/schema";
 import { generateJwtToken } from "../utils/generateJwtToken";
 import * as bcrypt from "bcryptjs";
-import { Role } from "../types/roles";
+import { Role, RoleType } from "../types/roles";
 import { getDatabase } from "../db";
+import { AppContext } from "../types/appContext";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -38,6 +39,26 @@ app.post("/login", async (c) => {
 });
 
 app.post("/register", async (c) => {
+  await registerUser(c, Role.USER);
+
+  return c.text("User created successfully");
+});
+
+app.post("/register/super-admin", async (c) => {
+  const db = getDatabase(c);
+  const superAdmin = await db.select().from(users).where(eq(users.role, Role.SUPER_ADMIN));
+
+  if (superAdmin.length > 0) {
+    console.error("Super admin already exists");
+    throw new HTTPException(400, { message: "Super admin already exists" });
+  }
+
+  await registerUser(c, Role.SUPER_ADMIN);
+
+  return c.text("Super admin created successfully");
+});
+
+async function registerUser(c: AppContext, role: RoleType) {
   const { email, password }: { email: string; password: string } =
     await c.req.json();
 
@@ -59,12 +80,10 @@ app.post("/register", async (c) => {
 
   await db
     .insert(users)
-    .values({ email, password: hashedPassword, role: Role.USER });
+    .values({ email, password: hashedPassword, role });
 
   const token = await generateJwtToken(email, c);
   c.header("Authorization", `Bearer ${token}`);
-
-  return c.text("User created successfully");
-});
+}
 
 export default app;

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -75,6 +75,7 @@ app.patch("/:id", async (c) => {
         console.error("Role is not valid");
         throw new HTTPException(400, { message: "Role is not valid" });
     }
+
     if (email && role) {
         await db.update(users).set({email, role}).where(eq(users.id, id));
     }
@@ -84,6 +85,7 @@ app.patch("/:id", async (c) => {
     if (role) {
         await db.update(users).set({role}).where(eq(users.id, id));
     }
+    
     return c.text("User updated successfully");
 });
 

--- a/src/middleware/admin.ts
+++ b/src/middleware/admin.ts
@@ -5,7 +5,7 @@ import { Role } from "../types/roles";
 
 export const admin = createMiddleware(async (c, next) => {
     const user = c.get("user");
-    if (user.role !== Role.ADMIN) {
+    if (user.role !== Role.ADMIN && user.role !== Role.SUPER_ADMIN) {
         console.error("User is not admin");
         throw new HTTPException(403, { message: "Forbidden" });
     }

--- a/src/types/roles.ts
+++ b/src/types/roles.ts
@@ -1,8 +1,9 @@
-export type RoleType = Role.USER | Role.ADMIN;
+export type RoleType = Role.USER | Role.ADMIN | Role.SUPER_ADMIN;
 
 export enum Role {
   USER = "user",
   ADMIN = "admin",
+  SUPER_ADMIN = "super_admin",
 }
 
-export const Roles = [Role.USER, Role.ADMIN];
+export const Roles = [Role.USER, Role.ADMIN, Role.SUPER_ADMIN];


### PR DESCRIPTION
Because drizzle does not support js migrations yet, in order to add an initial super admin, we need a special endpoint, that can only register a super admin once.

The endpoint will be removed in favor of a js migration with drizzle once the feature gets added.